### PR TITLE
Bug: redirect to correct submission message when PRN is present in API response

### DIFF
--- a/pppp/src/views/pay-patient/ReviewPage.vue
+++ b/pppp/src/views/pay-patient/ReviewPage.vue
@@ -120,7 +120,11 @@ export default {
                 event: 'submission failure',
                 response: response.data,
               });
-              this.navigateToSubmissionErrorPage();
+              if (planReferenceNumber) {
+                this.navigateToSubmissionPage();
+              } else {
+                this.navigateToSubmissionErrorPage();
+              }              
               break;
           }
         })

--- a/pppp/src/views/pay-practitioner/ReviewPage.vue
+++ b/pppp/src/views/pay-practitioner/ReviewPage.vue
@@ -120,7 +120,11 @@ export default {
                 event: 'submission failure',
                 response: response.data,
               });
-              this.navigateToSubmissionErrorPage();
+              if (planReferenceNumber) {
+                this.navigateToSubmissionPage();
+              } else {
+                this.navigateToSubmissionErrorPage();
+              }              
               break;
           }
         })

--- a/pppp/tests/unit/views/pay-patient/ReviewPage.spec.js
+++ b/pppp/tests/unit/views/pay-patient/ReviewPage.spec.js
@@ -530,7 +530,7 @@ describe("ReviewPage.vue pay patient submitForm()", () => {
     expect(spyOnLogServiceError).toHaveBeenCalled();
   });
 
-  it("calls logServiceError on DB Error PRN Present error", async () => {
+  it("calls spyOnNavigateToSubmissionPage on DB Error PRN Present error", async () => {
     jest
       .spyOn(apiService, "submitPayPatientApplication")
       .mockImplementationOnce(() =>

--- a/pppp/tests/unit/views/pay-patient/ReviewPage.spec.js
+++ b/pppp/tests/unit/views/pay-patient/ReviewPage.spec.js
@@ -114,12 +114,21 @@ const mockResponseMisc = {
   data: {
     applicationUuid: "ed8fcf17-fb1f-4b3d-93aa-1ba5fbfb2898",
     requestUuid: "d88ecb3b-0ce5-4849-a349-e91fd7b11618",
-    returnCode: "potato",
-    returnMessage: "Success",
-    planReferenceNumber: "1270900001",
+    returnCode: "-1",
+    returnMessage: "Error message",
   },
   status: 200,
   statusText: "OK",
+};
+
+const mockResponseDBErrorPrnPresent = {
+  data: {
+    applicationUuid: "80b041ce-d638-5961-e881-4b55d32c8cd2",
+    requestUuid: "01b041ce-d638-5961-e891-4b55d32c8cd2",
+    returnCode: "404",
+    returnMessage: "Not Found",
+    planReferenceNumber: "1301900007",
+  },
 };
 
 const next = jest.fn();
@@ -498,6 +507,7 @@ describe("ReviewPage.vue pay patient submitForm()", () => {
     wrapper.vm.submitForm();
     await wrapper.vm.$nextTick;
     expect(spyOnNavigateToSubmissionErrorPage).toHaveBeenCalled();
+    expect(spyOnNavigateToSubmissionPage).not.toHaveBeenCalled();
   });
 
   it("calls logServiceError on misc error", async () => {
@@ -507,6 +517,29 @@ describe("ReviewPage.vue pay patient submitForm()", () => {
     wrapper.vm.submitForm();
     await wrapper.vm.$nextTick;
     expect(spyOnLogServiceError).toHaveBeenCalled();
+  });
+
+  it("calls logServiceError on DB Error PRN Present error", async () => {
+    jest
+      .spyOn(apiService, "submitPayPatientApplication")
+      .mockImplementationOnce(() =>
+        Promise.resolve(mockResponseDBErrorPrnPresent)
+      );
+    wrapper.vm.submitForm();
+    await wrapper.vm.$nextTick;
+    expect(spyOnLogServiceError).toHaveBeenCalled();
+  });
+
+  it("calls logServiceError on DB Error PRN Present error", async () => {
+    jest
+      .spyOn(apiService, "submitPayPatientApplication")
+      .mockImplementationOnce(() =>
+        Promise.resolve(mockResponseDBErrorPrnPresent)
+      );
+    wrapper.vm.submitForm();
+    await wrapper.vm.$nextTick;
+    expect(spyOnNavigateToSubmissionPage).toHaveBeenCalled();
+    expect(spyOnNavigateToSubmissionErrorPage).not.toHaveBeenCalled();
   });
 
   //had difficulty replicating the conditions for an http error

--- a/pppp/tests/unit/views/pay-practitioner/ReviewPage.spec.js
+++ b/pppp/tests/unit/views/pay-practitioner/ReviewPage.spec.js
@@ -117,8 +117,8 @@ const mockResponseMisc = {
   data: {
     applicationUuid: "ed8fcf17-fb1f-4b3d-93aa-1ba5fbfb2898",
     requestUuid: "d88ecb3b-0ce5-4849-a349-e91fd7b11618",
-    returnCode: "potato",
-    returnMessage: "Success",
+    returnCode: "-1",
+    returnMessage: "Error message",
   },
   status: 200,
   statusText: "OK",

--- a/pppp/tests/unit/views/pay-practitioner/ReviewPage.spec.js
+++ b/pppp/tests/unit/views/pay-practitioner/ReviewPage.spec.js
@@ -119,10 +119,19 @@ const mockResponseMisc = {
     requestUuid: "d88ecb3b-0ce5-4849-a349-e91fd7b11618",
     returnCode: "potato",
     returnMessage: "Success",
-    planReferenceNumber: "1270900001",
   },
   status: 200,
   statusText: "OK",
+};
+
+const mockResponseDBErrorPrnPresent = {
+  data: {
+    applicationUuid: "80b041ce-d638-5961-e881-4b55d32c8cd2",
+    requestUuid: "01b041ce-d638-5961-e891-4b55d32c8cd2",
+    returnCode: "404",
+    returnMessage: "Not Found",
+    planReferenceNumber: "1301900007",
+  },
 };
 
 const next = jest.fn();
@@ -610,6 +619,7 @@ describe("ReviewPage.vue pay practitioner submitForm()", () => {
     wrapper.vm.submitForm();
     await wrapper.vm.$nextTick;
     expect(spyOnNavigateToSubmissionErrorPage).toHaveBeenCalled();
+    expect(spyOnNavigateToSubmissionPage).not.toHaveBeenCalled();
   });
 
   it("calls logServiceError on misc error", async () => {
@@ -619,6 +629,29 @@ describe("ReviewPage.vue pay practitioner submitForm()", () => {
     wrapper.vm.submitForm();
     await wrapper.vm.$nextTick;
     expect(spyOnLogServiceError).toHaveBeenCalled();
+  });
+
+  it("calls logServiceError on DB Error PRN Present error", async () => {
+    jest
+      .spyOn(apiService, "submitPayPractitionerApplication")
+      .mockImplementationOnce(() =>
+        Promise.resolve(mockResponseDBErrorPrnPresent)
+      );
+    wrapper.vm.submitForm();
+    await wrapper.vm.$nextTick;
+    expect(spyOnLogServiceError).toHaveBeenCalled();
+  });
+
+  it("calls spyOnNavigateToSubmissionPage on DB Error PRN Present error", async () => {
+    jest
+      .spyOn(apiService, "submitPayPractitionerApplication")
+      .mockImplementationOnce(() =>
+        Promise.resolve(mockResponseDBErrorPrnPresent)
+      );
+    wrapper.vm.submitForm();
+    await wrapper.vm.$nextTick;
+    expect(spyOnNavigateToSubmissionPage).toHaveBeenCalled();
+    expect(spyOnNavigateToSubmissionErrorPage).not.toHaveBeenCalled();
   });
 
   //had difficulty replicating the conditions for an http error


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X] After these changes, the app was run and still works as expected
- [X] Tests for these changes were added (if applicable)
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
--Introduces logic gate to the ReviewPage.vue for both Pay Patient and Pay Practitioner. If the API response contains a plan reference number in it (eg. if the database is down but the response is still processed by MAXImage), the page redirects to SubmissionPage instead of SubmissionErrorPage. 
--Updates tests accordingly and makes a few minor fixes to test names as well.

### Additional Notes:
--This approach was tested with Denis Brake, who manually turned off the database for me so I could evaluate the redirection code. I did this for both Pay Patient and Pay Practitioner successfully. Unit and E2E tests all pass.
--Completes the work required by ticket CLMWEBDE-94
