### PR TITLE
Update numeric validations for CSR pages

### DIFF
--- a/pppp/src/views/pay-patient/MainFormPage.vue
+++ b/pppp/src/views/pay-patient/MainFormPage.vue
@@ -1032,7 +1032,7 @@ export default {
             required: requiredIf(() => !isCSR(this.$router.currentRoute.path)),
             intValidator: optionalValidator(intValidator),
             positiveNumberValidator: optionalValidator(positiveNumberValidator),
-            nonZeroNumberValidator: optionalValidator(nonZeroNumberValidator),
+            nonZeroNumberValidator: optionalValidator(validateIf(!isCSR(this.$router.currentRoute.path), nonZeroNumberValidator)),
           },
           feeItem: {
             required: requiredIf(() => !isCSR(this.$router.currentRoute.path)),

--- a/pppp/src/views/pay-patient/MainFormPage.vue
+++ b/pppp/src/views/pay-patient/MainFormPage.vue
@@ -1166,6 +1166,11 @@ export default {
         if (this.medicalServiceClaims[i].feeItem) {
           this.medicalServiceClaims[i].feeItem = padLeadingZeros(this.medicalServiceClaims[i].feeItem, 5);
         }
+
+        // Set default "numberOfServices" to 00 
+        if (!this.medicalServiceClaims[i].numberOfServices) {
+          this.medicalServiceClaims[i].numberOfServices = '00';
+        }
         // Set default "calledStartTime" to "00:00".
         if (!this.medicalServiceClaims[i].calledStartTime
           || (

--- a/pppp/src/views/pay-patient/MainFormPage.vue
+++ b/pppp/src/views/pay-patient/MainFormPage.vue
@@ -977,7 +977,7 @@ export default {
       dependentNumber: {
         intValidator: optionalValidator(intValidator),
         positiveNumberValidator: optionalValidator(positiveNumberValidator),
-        dependentNumberValidator: optionalValidator(dependentNumberValidator),
+        dependentNumberValidator: optionalValidator(validateIf(!isCSR(this.$router.currentRoute.path), dependentNumberValidator)),
       },
       firstName: {
         required: requiredIf(() => !isCSR(this.$router.currentRoute.path)),

--- a/pppp/src/views/pay-practitioner/MainFormPage.vue
+++ b/pppp/src/views/pay-practitioner/MainFormPage.vue
@@ -1345,7 +1345,7 @@ export default {
       dependentNumber: {
         intValidator: optionalValidator(intValidator),
         positiveNumberValidator: optionalValidator(positiveNumberValidator),
-        dependentNumberValidator: optionalValidator(dependentNumberValidator),
+        dependentNumberValidator: optionalValidator(validateIf(!isCSR(this.$router.currentRoute.path), dependentNumberValidator)),
       },
       firstName: {
         required: requiredIf(() => !isCSR(this.$router.currentRoute.path)),

--- a/pppp/src/views/pay-practitioner/MainFormPage.vue
+++ b/pppp/src/views/pay-practitioner/MainFormPage.vue
@@ -1387,7 +1387,7 @@ export default {
             required: requiredIf(() => !isCSR(this.$router.currentRoute.path)),
             intValidator: optionalValidator(intValidator),
             positiveNumberValidator: optionalValidator(positiveNumberValidator),
-            nonZeroNumberValidator: optionalValidator(nonZeroNumberValidator),
+            nonZeroNumberValidator: optionalValidator(validateIf(!isCSR(this.$router.currentRoute.path), nonZeroNumberValidator)),
           },
           feeItem: {
             required: requiredIf(() => !isCSR(this.$router.currentRoute.path)),
@@ -1457,7 +1457,7 @@ export default {
             required: requiredIf(() => !isCSR(this.$router.currentRoute.path)),
             intValidator: optionalValidator(intValidator),
             positiveNumberValidator: optionalValidator(positiveNumberValidator),
-            nonZeroNumberValidator: optionalValidator(nonZeroNumberValidator),
+            nonZeroNumberValidator: optionalValidator(validateIf(!isCSR(this.$router.currentRoute.path), nonZeroNumberValidator)),
           },
           feeItem: {
             required: requiredIf(() => !isCSR(this.$router.currentRoute.path)),

--- a/pppp/src/views/pay-practitioner/MainFormPage.vue
+++ b/pppp/src/views/pay-practitioner/MainFormPage.vue
@@ -1593,6 +1593,12 @@ export default {
         if (this.medicalServiceClaims[i].feeItem) {
           this.medicalServiceClaims[i].feeItem = padLeadingZeros(this.medicalServiceClaims[i].feeItem, 5);
         }
+
+        // Set default "numberOfServices" to 00 
+        if (!this.medicalServiceClaims[i].numberOfServices) {
+          this.medicalServiceClaims[i].numberOfServices = '00';
+        }
+
         // Set default "calledStartTime" to "00:00".
         if (!this.medicalServiceClaims[i].calledStartTime
           || (
@@ -1625,6 +1631,11 @@ export default {
         // Pad Fee Items with leading zeros.
         if (this.hospitalVisitClaims[i].feeItem) {
           this.hospitalVisitClaims[i].feeItem = padLeadingZeros(this.hospitalVisitClaims[i].feeItem, 5);
+        }
+
+        // Set default "numberOfServices" to 00 
+        if (!this.hospitalVisitClaims[i].numberOfServices) {
+          this.hospitalVisitClaims[i].numberOfServices = '00';
         }
       }
       


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X] After these changes, the app was run and still works as expected
- [ ] Tests for these changes were added (if applicable) (tests to be completed on merge into main)
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
All changes are for pay patient and pay practitioner, for medical and hospital claims.

--Changes dependent number validator to check if it's a CSR (eg., no longer needs to be 00 or 66 on a CSR page)
--number of Services can now be a zero on a CSR page
--default number of services is now 00

### Additional Notes:
Completes tickets CLMWEBDE-100 and CLMWEBDE-95
