### PR TITLE
Phn mod check nine

### DIFF
--- a/pppp/src/helpers/validators.js
+++ b/pppp/src/helpers/validators.js
@@ -113,3 +113,13 @@ export const serviceDateCutOffValidator = (value, vm) => {
   }
   return true;
 }
+
+export const phnNineValidator = (value) => {
+  if (typeof value !== "string") {
+    return false;
+  }
+  if (value && value[0] === "9") {
+    return true;
+  }
+  return false;
+}

--- a/pppp/src/views/pay-patient/MainFormPage.vue
+++ b/pppp/src/views/pay-patient/MainFormPage.vue
@@ -43,8 +43,8 @@
               v-if="$v.phn.$dirty && !$v.phn.required"
               aria-live="assertive">Personal Health Number (PHN) is required.</div>
           <div class="text-danger"
-              v-if="$v.phn.$dirty && $v.phn.required && !$v.phn.phnValidator"
-              aria-live="assertive">Personal Health Number (PHN) must be valid.</div>
+              v-if="$v.phn.$dirty && $v.phn.required && (!$v.phn.phnValidator || !$v.phn.phnNineValidator)"
+              aria-live="assertive">The number you have entered is not a valid British Columbia PHN.</div>
           <DigitInput 
                 :label='"Dependant" + (isCSR ? "" : " (optional)") + ":"'
                 id='dependent-number'
@@ -688,7 +688,8 @@ import {
   serviceLocationCodeValidator,
   specialtyCodeValidator,
   submissionCodeValidator,
-  validateIf
+  validateIf,
+  phnNineValidator
 } from '@/helpers/validators';
 import {
   selectOptionsSubmissionCode,
@@ -998,6 +999,7 @@ export default {
       phn: {
         required: requiredIf(() => !isCSR(this.$router.currentRoute.path)),
         phnValidator: optionalValidator(phnValidator),
+        phnNineValidator: optionalValidator(phnNineValidator),
       },
       dependentNumber: {
         intValidator: optionalValidator(intValidator),

--- a/pppp/src/views/pay-practitioner/MainFormPage.vue
+++ b/pppp/src/views/pay-practitioner/MainFormPage.vue
@@ -43,8 +43,8 @@
               v-if="$v.phn.$dirty && !$v.phn.required"
               aria-live="assertive">Personal Health Number (PHN) is required.</div>
           <div class="text-danger"
-              v-if="$v.phn.$dirty && $v.phn.required && !$v.phn.phnValidator"
-              aria-live="assertive">Personal Health Number (PHN) must be valid.</div>
+              v-if="$v.phn.$dirty && $v.phn.required && (!$v.phn.phnValidator || !$v.phn.phnNineValidator)"
+              aria-live="assertive">The number you have entered is not a valid British Columbia PHN.</div>
           <DigitInput 
                 :label='"Dependant" + (isCSR ? "" : " (optional)") + ":"'
                 id='dependent-number'
@@ -921,7 +921,8 @@ import {
   serviceLocationCodeValidator,
   specialtyCodeValidator,
   submissionCodeValidator,
-  validateIf
+  validateIf,
+  phnNineValidator
 } from '@/helpers/validators';
 import {
   selectOptionsSubmissionCode,
@@ -1368,6 +1369,7 @@ export default {
       phn: {
         required: requiredIf(() => !isCSR(this.$router.currentRoute.path)),
         phnValidator: optionalValidator(phnValidator),
+        phnNineValidator: optionalValidator(phnNineValidator),
       },
       dependentNumber: {
         intValidator: optionalValidator(intValidator),

--- a/pppp/tests/unit/helpers/validators.spec.js
+++ b/pppp/tests/unit/helpers/validators.spec.js
@@ -7,6 +7,7 @@ import {
   birthDateValidator,
   serviceDateValidator,
 } from "@/helpers/validators.js";
+import { phnNineValidator } from "../../../src/helpers/validators";
 
 describe("validators.js bcPostalCodeValidator()", () => {
   afterEach(() => {
@@ -362,6 +363,47 @@ describe("validators.js motorVehicleAccidentClaimNumberMaskValidator()", () => {
 
   it("returns false if given a string with too many characters", () => {
     const result = motorVehicleAccidentClaimNumberMaskValidator("A12345678");
+    expect(result).toBe(false);
+  });
+});
+
+describe("validators.js phnNineValidator()", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("returns true if given a string that starts with 9", () => {
+    const result = phnNineValidator("9999999998");
+    expect(result).toBe(true);
+  });
+
+  it("returns true if given a string that starts with 9 (2)", () => {
+    const result = phnNineValidator("9");
+    expect(result).toBe(true);
+  });
+
+  it("returns false if given a string that that does NOT start with 9", () => {
+    const result = phnNineValidator("7999999998");
+    expect(result).toBe(false);
+  });
+
+  it("returns false if given an empty value", () => {
+    const result = phnNineValidator();
+    expect(result).toBe(false);
+  });  
+
+  it("returns false if given an integer", () => {
+    const result = phnNineValidator(9999999998);
+    expect(result).toBe(false);
+  });
+
+  it("returns false if given an array", () => {
+    const result = phnNineValidator(["9", "9"]);
+    expect(result).toBe(false);
+  });
+
+  it("returns false if given an object", () => {
+    const result = phnNineValidator({"9": "9", "8": "9"});
     expect(result).toBe(false);
   });
 });

--- a/pppp/tests/unit/views/pay-patient/MainFormPageValidateFieldsCSR.spec.js
+++ b/pppp/tests/unit/views/pay-patient/MainFormPageValidateFieldsCSR.spec.js
@@ -605,6 +605,15 @@ describe("MainFormPage.vue validateFields(), CSR", () => {
     expect(spyOnNavigateToNextPage).not.toHaveBeenCalled();
   });
 
+  it("(PHN) flags invalid if PHN doesn't start with 9", async () => {
+    Object.assign(wrapper.vm, cloneDeep(passingData));
+    await wrapper.setData({ phn: "7999 999 998" });
+    await wrapper.vm.validateFields();
+    await wrapper.vm.$nextTick;
+    expect(spyOnScrollToError).toHaveBeenCalled();
+    expect(spyOnNavigateToNextPage).not.toHaveBeenCalled();
+  });
+
   it("(dependentNumber) flags invalid if non number", async () => {
     Object.assign(wrapper.vm, cloneDeep(passingData));
     await wrapper.setData({ dependentNumber: "a" });

--- a/pppp/tests/unit/views/pay-patient/MainFormPageValidateFieldsPublic.spec.js
+++ b/pppp/tests/unit/views/pay-patient/MainFormPageValidateFieldsPublic.spec.js
@@ -605,6 +605,15 @@ describe("MainFormPage.vue validateFields(), public", () => {
     expect(spyOnNavigateToNextPage).not.toHaveBeenCalled();
   });
 
+  it("(PHN) flags invalid if PHN doesn't start with 9", async () => {
+    Object.assign(wrapper.vm, cloneDeep(passingData));
+    await wrapper.setData({ phn: "7999 999 998" });
+    await wrapper.vm.validateFields();
+    await wrapper.vm.$nextTick;
+    expect(spyOnScrollToError).toHaveBeenCalled();
+    expect(spyOnNavigateToNextPage).not.toHaveBeenCalled();
+  });
+
   it("(dependentNumber) flags invalid if non number", async () => {
     Object.assign(wrapper.vm, cloneDeep(passingData));
     await wrapper.setData({ dependentNumber: "a" });

--- a/pppp/tests/unit/views/pay-practitioner/MainFormPageValidateFieldsCSR.spec.js
+++ b/pppp/tests/unit/views/pay-practitioner/MainFormPageValidateFieldsCSR.spec.js
@@ -653,6 +653,15 @@ describe("MainFormPage.vue validateFields(), CSR", () => {
     expect(spyOnNavigateToNextPage).not.toHaveBeenCalled();
   });
 
+  it("(PHN) flags invalid if PHN doesn't start with 9", async () => {
+    Object.assign(wrapper.vm, cloneDeep(passingData));
+    await wrapper.setData({ phn: "7999 999 998" });
+    await wrapper.vm.validateFields();
+    await wrapper.vm.$nextTick;
+    expect(spyOnScrollToError).toHaveBeenCalled();
+    expect(spyOnNavigateToNextPage).not.toHaveBeenCalled();
+  });
+
   it("(dependentNumber) flags invalid if non number", async () => {
     Object.assign(wrapper.vm, cloneDeep(passingData));
     await wrapper.setData({ dependentNumber: "a" });

--- a/pppp/tests/unit/views/pay-practitioner/MainFormPageValidateFieldsPublic.spec.js
+++ b/pppp/tests/unit/views/pay-practitioner/MainFormPageValidateFieldsPublic.spec.js
@@ -653,6 +653,15 @@ describe("MainFormPage.vue validateFields(), public", () => {
     expect(spyOnNavigateToNextPage).not.toHaveBeenCalled();
   });
 
+  it("(PHN) flags invalid if PHN doesn't start with 9", async () => {
+    Object.assign(wrapper.vm, cloneDeep(passingData));
+    await wrapper.setData({ phn: "7999 999 998" });
+    await wrapper.vm.validateFields();
+    await wrapper.vm.$nextTick;
+    expect(spyOnScrollToError).toHaveBeenCalled();
+    expect(spyOnNavigateToNextPage).not.toHaveBeenCalled();
+  });
+
   it("(dependentNumber) flags invalid if non number", async () => {
     Object.assign(wrapper.vm, cloneDeep(passingData));
     await wrapper.setData({ dependentNumber: "a" });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X] After these changes, the app was run and still works as expected
- [X] Tests for these changes were added (if applicable)
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
--Add "check to make sure first digit of phn is a 9" validator to helpers
--Import phnNineValidator to main form, add to the list of existing phn validators (pay patient + pay prac)
--Change validation error to check for phnNineValidator (pay patient + pay prac)
--Change validation error message language (pay patient + pay prac)
--Add validator-specific testing
--Add main form page testing to make sure it doesn't proceed if there's a validator error

### Additional Notes:
Was NOT able to run the end-to-end tests, as these appear to have broken in commit 7abe64d7bdee863721080636cd7fda6d57965031. 