### PR TITLE
Dynatrace version bump (msp-service 1.0.0 -> 2.0.0, splunk-forwarder  0.9.0 -> 1.0.0 )

### DIFF
--- a/msp-service/package-lock.json
+++ b/msp-service/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msp-service",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/msp-service/package.json
+++ b/msp-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msp-service",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/splunk-forwarder/package-lock.json
+++ b/splunk-forwarder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-forwarder",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/splunk-forwarder/package.json
+++ b/splunk-forwarder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-forwarder",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "Forward log request to remove Splunk server",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [ ] Tests for these changes were added (if applicable) 
- [x] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Version bump to cover all of the Splunk -> Dynatrace changes

### Additional Notes:
PPPP unit tests pass. E2E tests for PPPP pass. `npm run build` passes for splunk forwarder and msp-service. `npm audit` vulnerabilities in PPPP were NOT fixed, as these will be handled by the upcoming Vue 3 upgrade. `npm audit` vulnerabilities for splunk forwarder and msp-service were NOT fixed, as they are out of scope.