### PR TITLE
Add force image build to pppp-web workflow

### DIFF
--- a/.github/workflows/pppp-web.yaml
+++ b/.github/workflows/pppp-web.yaml
@@ -7,9 +7,14 @@ on:
       - "pppp/src/**/*.js"
       - "pppp/src/**/*.scss"
       - "pppp/src/**/*.vue"
-      - "pppp/tests/unit/**/*.spec.js"
       - "pppp/package*.json"
   workflow_dispatch:
+    inputs:
+      force-image-build:
+        description: "Force an image build/deployment to DEV outside of a merge to main"
+        required: false
+        default: false
+        type: boolean
 env:
   NAMESPACE: 0752cb-tools
   ARTIFACT_BUILD_NAME: pppp-web-artifact-build
@@ -69,7 +74,7 @@ jobs:
         env:
           CI: "true"
   image-build:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force-image-build == 'true'}}
     runs-on: ubuntu-latest
     needs: [test, build]
     steps:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [ ] After these changes, the app was run and still works as expected
- [ ] Tests for these changes were added (if applicable)
- [ ] `npm audit` was checked, applicable vulnerabilities were updated
- [ ] `npm run build` passes
- [ ] `npm run lint` has no unexpected errors
- [ ] `npm run format` has no unexpected errors
- [ ] All existing unit tests were run and still pass (`npm run test:unit`)
- [ ] End-to-end tests were run and still pass in Chrome, Firefox, and Edge without unexpected console errors (`npm run test:e2e`)

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
ci: add workflow_dispatch to allow us to force an image build outside of a merge to main, also remove unit tests as a workflow trigger

### Additional Notes:
No application changes-- Github workflow only